### PR TITLE
修复Chrome下 `测试连接，成功显示版本号` 永远失败的BUG

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -16,7 +16,7 @@
       "128": "images/logo128.png"
    },
    "manifest_version": 2,
-   "permissions": [ "cookies", "tabs", "*://*.baidu.com/*"],
+   "permissions": [ "cookies", "tabs", "*://*.baidu.com/*", "http://*/", "https://*/*"],
    "name": "__MSG_appName__",
    "version": "0.3.4"
 }


### PR DESCRIPTION
网页里面的XMLHttpRequest并不是Cross-origin的, 于是我们要用window.postMessage方式来使用Chrome Extension XMLHttpRequest来解决。