### PR TITLE
add naive pooling buffer

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -33,23 +33,20 @@ var HttpSendRead = function(info) {
         }
         http.onreadystatechange = function() {
             if (http.readyState == 4) {
+                pendingSend -= 1;
                 if ((http.status == 200 && http.status < 300) || http.status == 304) {
                     clearTimeout(timeId);
                     if (info.dataType == "json") {
-                        pendingSend -= 1;
                         resolve(JSON.parse(http.responseText), http.status, http);
                     }
                     else if (info.dataType == "SCRIPT") {
                         // eval(http.responseText);
-                        pendingSend -= 1;
                         resolve(http.responseText, http.status, http);
                     }
-                    pendingSend -= 1;
                     resolve(http, http.status);
                 }
                 else {
                     clearTimeout(timeId);
-                    pendingSend -= 1;
                     reject(http, http.statusText, http.status);
                 }
             }

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -28,6 +28,8 @@ var HttpSendRead = function(info) {
         var timeId = setTimeout(httpclose, timeout);
         function httpclose() {
             http.abort();
+            pendingSend -= 1;
+            reject(http);
         }
         http.onreadystatechange = function() {
             if (http.readyState == 4) {
@@ -42,6 +44,8 @@ var HttpSendRead = function(info) {
                         pendingSend -= 1;
                         resolve(http.responseText, http.status, http);
                     }
+                    pendingSend -= 1;
+                    resolve(http, http.status);
                 }
                 else {
                     clearTimeout(timeId);


### PR DESCRIPTION
Hi, acgotaku. I have implemented a timer-based naive buffering for your background.js.
Please review it and test it. I don't know how to test it on my machine locally.

A better solution is to write a mini-event emitter, which preempt the burden of polling. But it is a little more complex. If you prefer the event-emitter approach, I will change this implementation.