### PR TITLE
导出IDM文件问题

### DIFF
--- a/chrome/src/js/lib/core.js
+++ b/chrome/src/js/lib/core.js
@@ -195,7 +195,7 @@ class Core {
       }
       aria2CmdTxt.push(aria2CmdLine)
       aria2Txt.push(aria2Line)
-      const idmLine = ['<', file.link, this.getHeader('idm'), `out=${name}`, '>\r\n'].join('\r\n')
+      const idmLine = ['<', file.link, this.getHeader('idm'), `out=${name}`, '>'].join('\r\n')
       idmTxt.push(idmLine)
       downloadLinkTxt.push(file.link)
     })


### PR DESCRIPTION
导出IDM的ef2文件多了一个换行导致IDM只能导入众多下载任务里的第一个下载任务