### PR TITLE
Fixed "cannot read property 'split' of null on search result" issue a…

### DIFF
--- a/chrome/src/js/home.js
+++ b/chrome/src/js/home.js
@@ -81,6 +81,8 @@ class Home extends Downloader {
     const fold = Core.getConfigData('fold')
     if (fold === -1 || path === '/') {
       return 1
+    } else if (Core.getHashParameter('/search?key')) {
+      return 1
     } else {
       const dir = path.split('/')
       let count = 0


### PR DESCRIPTION
…t search result page

![screenshot_2018-08-20_at_10 05 08_am__baidu-export-issue-at-search-result-page](https://user-images.githubusercontent.com/2653486/44317019-8bdb7b00-a461-11e8-8f54-e07b3a47df1a.png)
