### PR TITLE
Change appid in generated download links

### DIFF
--- a/chrome/src/js/home.js
+++ b/chrome/src/js/home.js
@@ -97,7 +97,7 @@ class Home extends Downloader {
     for (let key in files) {
       this.fileDownloadInfo.push({
         name: files[key].path.substr(prefix),
-        link: `${location.protocol}//pcs.baidu.com/rest/2.0/pcs/file?method=download&app_id=250528&path=${encodeURIComponent(files[key].path)}`,
+        link: `${location.protocol}//pcs.baidu.com/rest/2.0/pcs/file?method=download&app_id=624966&path=${encodeURIComponent(files[key].path)}`,
         md5: files[key].md5
       })
     }

--- a/chrome/src/js/share.js
+++ b/chrome/src/js/share.js
@@ -228,7 +228,7 @@ class Share extends Downloader {
       timestamp: window.yunData.TIMESTAMP,
       sign: window.yunData.SIGN,
       bdstoken: window.yunData.MYBDSTOKEN,
-      app_id: 250528,
+      app_id: 624966,
       channel: 'chunlei',
       clienttype: 0,
       web: 1

--- a/chrome/src/js/share.js
+++ b/chrome/src/js/share.js
@@ -155,7 +155,7 @@ class Share extends Downloader {
     const search = {
       prod: 'share',
       bdstoken: window.yunData.MYBDSTOKEN,
-      app_id: 250528,
+      app_id: 624966,
       channel: 'chunlei',
       clienttype: 0,
       web: 1


### PR DESCRIPTION
Based on https://github.com/acgotaku/BaiduExporter/issues/667#issuecomment-546771395. I can verify substantial speed up compared to original appid download link which is limited to less than 100kbps.

However no extensive tests are carried out for now, so there is no guarantee the new link is valid for every scenarios. But it does help in my user case.

Just leaving this PR for anyone who may think it helpful.